### PR TITLE
Base16 shell integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,17 @@ Add the theme to your `~/.config/rofi/config`
 mkdir ~/.config/rofi
 curl https://raw.githubusercontent.com/0xdec/base16-rofi/master/themes/base16-default-dark.config >> ~/.config/rofi/config
 ```
+
+### Base16-shell hook
+
+This repo also provides an hook to switch the rofi colorscheme automatically when a base16_shell theme is set. The setup is pretty straightforward:
+
+```
+> export BASE16_SHELL_HOOKS=$HOME/.config/base16-shell/hooks
+> mkdir -p $BASE16_SHELL_HOOKS
+> cp hook/rofi.sh $BASE16_SHELL_HOOKS && chmod +x $BASE16_SHELL_HOOK/rofi.sh
+```
+
+Then set the `rofi_config_file` and `rofi_themes_dir` variables in the script.
+
+

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ curl https://raw.githubusercontent.com/0xdec/base16-rofi/master/themes/base16-de
 
 ### Base16-shell hook
 
-This repo also provides an hook to switch the rofi colorscheme automatically when a base16_shell theme is set. The setup is pretty straightforward:
+This repo also provides a hook to switch the rofi colorscheme automatically when a base16_shell theme is set. The setup is pretty straightforward:
 
 ```
 > export BASE16_SHELL_HOOKS=$HOME/.config/base16-shell/hooks

--- a/hook/rofi.sh
+++ b/hook/rofi.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+rofi_config_file=$HOME/.config/rofi/config
+rofi_themes_dir=$HOME/sources/base16-rofi/themes
+
+rofi_theme_file=$rofi_themes_dir/base16-$BASE16_THEME.config
+if [ -f "$rofi_theme_file" ] && [ -f $rofi_config_file ]; then
+  cp "$rofi_theme_file" "$rofi_config_file"
+  echo 'Rofi theme updated'
+fi


### PR DESCRIPTION
This PR includes an executable hook to allow integration with the [base16-shell](https://github.com/chriskempson/base16-shell) command line tool. This way, when changing shell colors from the command line via e.g. `base16_nord`, the rofi config file gets automatically updated with the corresponding colorscheme.
