### PR TITLE
Fixes color config only

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -4,7 +4,7 @@ default:
 
 colors:
     extension: .rasi
-    output: themes
+    output: colors
 
 old:
     extension: .config


### PR DESCRIPTION
Hi, the colors only file overwrites the default .rasi files.
I've moved them to a colors folder since the color files are no full themes, hope that doesn't break something.