### PR TITLE
Update template for rofi 1.7.0

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -61,6 +61,10 @@ listview {
     scrollbar:        true;
     padding:          2px 0px 0px ;
 }
+element-text, element-icon {
+    background-color: inherit;
+    text-color:       inherit;
+}
 element {
     border:           0;
     padding:          1px ;


### PR DESCRIPTION
In version 1.7.0, Rofi changed certain parts of its theme implementation
and now requires another entry in order to set the text color.

Also, the old-style config files are no longer supported as of this
version, so only the .rasi config files need to be updated