### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017 Jordi Pakey-Rodriguez
+Copyright (c) 2022 [Tinted Theming](https://github.com/tinted-theming)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 base16-rofi
 ===========
 
-[Base16](https://github.com/chriskempson/base16) for [Rofi](https://github.com/DaveDavenport/rofi)
+[Base16](https://github.com/tinted-theming/home) for [Rofi](https://github.com/DaveDavenport/rofi)
 
 ### Installation
 
 Copy or link the desired base16-*.rasi theme files to `~/.local/share/rofi/themes/`.
 ```sh
-git clone https://github.com/jordiorlando/base16-rofi.git
+git clone https://github.com/tinted-theming/base16-rofi.git
 ln -s base16-rofi ~/.local/share/rofi/themes/
 rofi -theme base16-default-dark
 ```

--- a/templates/colors.mustache
+++ b/templates/colors.mustache
@@ -3,7 +3,7 @@
  *
  * Authors
  *  Scheme: {{scheme-author}}
- *  Template: Jordi Pakey-Rodriguez (https://github.com/0xdec), Andrea Scarpino (https://github.com/ilpianista)
+ *  Template: Tinted Theming (https://github.com/tinted-theming)
  */
 
 * {

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -3,7 +3,7 @@
  *
  * Authors
  *  Scheme: {{scheme-author}}
- *  Template: Jordi Pakey-Rodriguez (https://github.com/0xdec), Andrea Scarpino (https://github.com/ilpianista)
+ *  Template: Tinted Theming (https://github.com/tinted-theming)
  */
 
 * {

--- a/templates/old.mustache
+++ b/templates/old.mustache
@@ -1,5 +1,6 @@
 ! Base16 {{scheme-name}}
-! Author: {{scheme-author}}
+! Scheme author: {{scheme-author}}
+! Template author: Tinted Theming (https://github.com/tinted-theming)
 
 ! base00: #{{base00-hex}}
 ! base01: #{{base01-hex}}


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.